### PR TITLE
add: erc2335 enc/dec function

### DIFF
--- a/crypto/erc2335/erc2335.go
+++ b/crypto/erc2335/erc2335.go
@@ -1,0 +1,69 @@
+package erc2335
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/babylonlabs-io/babylon/crypto/bls12381"
+	"github.com/pkg/errors"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
+)
+
+// Encrypt encrypts a BLS private key using the EIP-2335 format
+func EncryptBLS(privKey *bls12381.PrivateKey, password string) ([]byte, error) {
+	if privKey == nil {
+		return nil, errors.New("private key cannot be nil")
+	}
+
+	encryptor := keystorev4.New()
+	cryptoFields, err := encryptor.Encrypt(*privKey, password)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to encrypt private key")
+	}
+
+	pubKey := privKey.PubKey().Bytes()
+
+	// Create the keystore json structure
+	keystoreJSON := struct {
+		Crypto  map[string]interface{} `json:"crypto"`
+		Version uint                   `json:"version"`
+		UUID    string                 `json:"uuid"`
+		Path    string                 `json:"path"`
+		Pubkey  string                 `json:"pubkey"`
+	}{
+		Crypto:  cryptoFields,
+		Version: 4,
+		Pubkey:  fmt.Sprintf("%x", pubKey),
+	}
+
+	return json.Marshal(keystoreJSON)
+}
+
+// Decrypt decrypts an EIP-2335 keystore JSON and returns the BLS private key
+func DecryptBLS(keystoreJSON []byte, password string) (bls12381.PrivateKey, error) {
+	// Parse the keystore json
+	var keystore struct {
+		Crypto  map[string]interface{} `json:"crypto"`
+		Version uint                   `json:"version"`
+		UUID    string                 `json:"uuid"`
+		Path    string                 `json:"path"`
+		Pubkey  string                 `json:"pubkey"`
+	}
+
+	if err := json.Unmarshal(keystoreJSON, &keystore); err != nil {
+		return nil, errors.Wrap(err, "failed to parse keystore json")
+	}
+
+	// Verify version
+	if keystore.Version != 4 {
+		return nil, fmt.Errorf("invalid keystore version: %d", keystore.Version)
+	}
+
+	encryptor := keystorev4.New()
+	privateKeyBytes, err := encryptor.Decrypt(keystore.Crypto, password)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decrypt keystore")
+	}
+	return bls12381.PrivateKey(privateKeyBytes), nil
+
+}

--- a/crypto/erc2335/erc2335_test.go
+++ b/crypto/erc2335/erc2335_test.go
@@ -1,0 +1,37 @@
+package erc2335
+
+import (
+	"testing"
+
+	"github.com/babylonlabs-io/babylon/crypto/bls12381"
+	"github.com/test-go/testify/require"
+)
+
+func TestEncryptBLS(t *testing.T) {
+	// TODO
+	t.Run("create bls key", func(t *testing.T) {
+		// TODO
+		blsPrivKey := bls12381.GenPrivKey()
+		password := "password"
+
+		t.Run("encrypt bls key", func(t *testing.T) {
+			// TODO
+			encryptedBlsKey, err := EncryptBLS(&blsPrivKey, password)
+			require.NoError(t, err)
+			t.Logf("encrypted bls key: %s", encryptedBlsKey)
+
+			t.Run("decrypt bls key", func(t *testing.T) {
+				// TODO
+				decryptedBlsKey, err := DecryptBLS(encryptedBlsKey, password)
+				require.NoError(t, err)
+				require.Equal(t, blsPrivKey, decryptedBlsKey)
+			})
+
+			t.Run("decrypt bls key with wrong password", func(t *testing.T) {
+				// TODO
+				_, err := DecryptBLS(encryptedBlsKey, "wrong password")
+				require.Error(t, err)
+			})
+		})
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -233,9 +233,11 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/strangelove-ventures/cometbft-client v0.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/test-go/testify v1.1.4
 	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
+	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1115,6 +1115,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
+github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
+github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
@@ -1137,6 +1139,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vulpine-io/io-test v1.0.0 h1:Ot8vMh+ssm1VWDAwJ3U4C5qG9aRnr5YfQFZPNZBAUGI=
 github.com/vulpine-io/io-test v1.0.0/go.mod h1:X1I+p5GCxVX9m4nFd1HBtr2bVX9v1ZE6x8w+Obt36AU=
+github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1 h1:9j7bpwjT9wmwBb54ZkBhTm1uNIlFFcCJXefd/YskZPw=
+github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1/go.mod h1:+tI1VD76E1WINI+Nstg7RVGpUolL5ql10nu2YztMO/4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=


### PR DESCRIPTION
## Description

This PR adds an erc2335 structure for storing encrypted BLS keys. Specifically:
- Import "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4" library for erc2335 
- Functions for encrypt/decrypt BLS

To generate the BLS key, the bls structure written in `crypto/bls12381` is used.

## Tasks

- Create erc2335 type of structure from bls private key and password (encrypt)
- Returns the bls private key using a structure of type erc2335 and a password (decrypt)
- Unit tests